### PR TITLE
Deprecate use of apt_key for elastic repo

### DIFF
--- a/ansible/monitor/monitor.yaml
+++ b/ansible/monitor/monitor.yaml
@@ -7,7 +7,10 @@
   gather_facts: no
   vars:
     cur_env: "{{ lookup('env', 'CUR_ENV') | default('devel', True) }}"
+    elastic_repo_url: https://artifacts.elastic.co/packages/8.x/apt
     metricbeat_ca_path: /etc/metricbeat/elasticsearch_http_ca.crt
+    key_staging_path: /root/elasticsearch-armored.gpg
+    key_final_path: /usr/share/keyrings/elasticsearch-archive-keyring.gpg
   tasks:
     - debug:
         var: cur_env
@@ -28,13 +31,27 @@
         - name: Install GPG so `apt_key` works.
           apt:
             name: gpg
-        # TODO: `apt_key` module is deprecated. Debian has decided to "simplify" things by deprecating the `apt-key` command without providing a convenient command that fills the same niche.
-        - name: Install the elastic.co repo key.
-          apt_key:
+        - name: Download elastic.co repo key
+          get_url:
             url: https://artifacts.elastic.co/GPG-KEY-elasticsearch
-        - name: Install the elastic.co repo.
-          apt_repository:
-            repo: deb https://artifacts.elastic.co/packages/8.x/apt stable main
+            dest: "{{ key_staging_path }}"
+            checksum: sha256:10e406ba504706f44fbfa57a8daba5cec2678b31c1722e262ebecb5102d07659
+        - name: Dearmor the GPG key
+          shell: "gpg --dearmor -o {{ key_final_path }} < {{ key_staging_path }}"
+          args:
+            creates: "{{ key_final_path }}"
+        - name: Add the elastic.co repo sources.list.d/ file
+          vars:
+            config_path: /etc/apt/sources.list.d/elasticsearch.list
+          template:
+            src: "templates/{{ config_path }}"
+            dest: "{{ config_path }}"
+            owner: root
+            group: root
+            mode: 0644
+        - name: Load cache for elastic repo
+          apt:
+            update_cache: yes
     #### Elasticsearch
     - name: Elasticsearch install + config
       block:

--- a/ansible/monitor/templates/etc/apt/sources.list.d/elasticsearch.list
+++ b/ansible/monitor/templates/etc/apt/sources.list.d/elasticsearch.list
@@ -1,0 +1,1 @@
+deb [signed-by={{ key_final_path }}] {{ elastic_repo_url }} stable main


### PR DESCRIPTION
The program `apt-key` is deprecated for security reasons. Debian 12 will not include `apt-key`, and Debian 11 only includes it for backwards compatibility.

> Use of apt-key is deprecated, except for the use of apt-key del in maintainer scripts to remove existing keys from the main keyring.

- https://www.linuxuprising.com/2021/01/apt-key-is-deprecated-how-to-add.html
- https://manpages.debian.org/bullseye/apt/apt-key.8.en.html
- https://docs.ansible.com/ansible/latest/collections/ansible/builtin/apt_key_module.html

Basically, the problem is that *any* key in the keyring is assumed to be trusted completely, and can be used to sign *any* package in *any* repo. The model they're transitioning to involves specifying the signing public key for each repo in that repo's config, so that key *must* be used for every package in that repo, and is *only* trusted for packages within that repo.