### PR TITLE
added caveat about playbook usage lifecycle

### DIFF
--- a/ansible/monitor/README.md
+++ b/ansible/monitor/README.md
@@ -10,6 +10,9 @@
 ## What is this code?
 
 The [ansible][] playbook here (`monitor.yaml`) sets up the [Elastic stack][] (Elasticsearch, Kibana, and Metricbeat) v. >= 8.2 on a Debian 11 host.
+I expect this playbook will only be run a few times against any individual host- the idea here is to bake an image, not use ansible for continued maintenance.
+Running the playbook multiple times shouldn't break anything, but it does generate a registration token for kibana to connect to elasticsearch each time, and load kibana dashboards for metricbeat.
+Those tokens each expire after 30 minutes though, so I'm not sure whether multiple registrations would be an issue.
 
 ## How do I run it?
 


### PR DESCRIPTION
The playbook is meant to be run only once, maybe a few times if the first time fails for some reason.
It's not meant to be run every day or every hour, for example. I don't know whether that might lead to a resource leak issue, since I don't know exactly what the setup scripts do for e.g. metricbeat.